### PR TITLE
Consistently use NSInteger typedefs

### DIFF
--- a/EDSemver/EDSemver.m
+++ b/EDSemver/EDSemver.m
@@ -10,9 +10,9 @@
 
 @interface EDSemver ()
 @property (readwrite) BOOL isValid;
-@property (readwrite) int major;
-@property (readwrite) int minor;
-@property (readwrite) int patch;
+@property (readwrite) NSInteger major;
+@property (readwrite) NSInteger minor;
+@property (readwrite) NSInteger patch;
 @property (readwrite) NSString *prerelease;
 @property (readwrite) NSString *build;
 @property (readwrite) NSArray *pr;
@@ -64,9 +64,9 @@ static NSString *const IGNORE_EQ                = @"=";
         // Check & set properties
         _isValid    = [self check];
         if (_isValid) {
-            _major      = [_version[0] intValue];
-            _minor      = [_version[1] intValue];
-            _patch      = [_version[2] intValue];
+            _major      = [_version[0] integerValue];
+            _minor      = [_version[1] integerValue];
+            _patch      = [_version[2] integerValue];
             _prerelease = _version[3];
             _build      = _version[4];
             _pr         = [self parse:_prerelease strict:NO];

--- a/Project/semverTests/EDSemverBenchmark.m
+++ b/Project/semverTests/EDSemverBenchmark.m
@@ -22,13 +22,13 @@
 - (void)setUp
 {
     [super setUp];
-    
+
     _list = @[@"1.2.3", @"v1.2.3", @"1.2.3-foo", @"1.0.0-alpha", @"1.0-alpha", @"1-alpha", @"   1.2.3", @"1.2.3 ", @"v1.0.0-alpha", @"v1.2-alpha+123"];
 }
 
 - (void)testBenchmark
 {
-    for (int i = 0; i < 1000; i++) {
+    for (NSUInteger i = 0; i < 1000; i++) {
         EDSemver *ver = [[EDSemver alloc] initWithString:[_list objectAtIndex:i % 10]];
         STAssertTrue([ver isValid], VALID_DESC);
     }


### PR DESCRIPTION
`NSInteger` != `int` on all platforms; native types (e.g. `NSInteger`) should generally be preferred for platform agnostic code.

In particular, the library won't compile for armv64 because `EDServer`'s version properties are declared as `NSInteger` externally, but as `int` internally. Those are the same thing on 32-bit machine but not a 64-bit machine:

![screen shot 2014-01-13 at 3 20 40 pm](https://f.cloud.github.com/assets/141447/1905031/99a12456-7c98-11e3-9ddf-e33bae2b378f.png)

Thanks for the great little library!
