### PR TITLE
Make original value public

### DIFF
--- a/EDSemver/EDSemver.h
+++ b/EDSemver/EDSemver.h
@@ -10,6 +10,7 @@
 
 @interface EDSemver : NSObject
 
+@property (readonly) NSString *original;
 @property (readonly) NSInteger major;
 @property (readonly) NSInteger minor;
 @property (readonly) NSInteger patch;

--- a/EDSemver/EDSemver.m
+++ b/EDSemver/EDSemver.m
@@ -17,7 +17,6 @@
 @property (readwrite) NSString *build;
 @property (readwrite) NSArray *pr;
 
-@property NSString *original;
 @property NSArray *version;
 @end
 


### PR DESCRIPTION
In my app I have knowledge of the current version and a proposed upgrade version. I'm using `EDSemver` to compare the two to determine if the app is out of date. If it is I'd like to show an alert to the user to tell them there's version foobarbaz available. To save myself copying the new version string from wherever it comes, feeding it into a `EDSemver` instance and then referring to the copied version for the alert I publicized `original` out of `EDSemver` so I can use it in the alert.

And then I made this super slick, all-tests-passing, hyper complicated PR. 

**Edit:** I realize that `description` and `debugDescription` are spitting out `original` but I don't consider that a good use of either of those methods. To keep this PR focused I wanted to only expose `original`. If you're open to it I'd have another PR change `description` to listing the broken down version values with their associated labels.
