### PR TITLE
Declare support for tvOS 9.0 in the podspec

### DIFF
--- a/EDSemver.podspec
+++ b/EDSemver.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/thisandagain/semver.git", :tag => "v0.3.1" }
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.8'
+  s.tvos.deployment_target = '9.0'
   s.source_files = 'EDSemver'
   s.requires_arc = true
 end


### PR DESCRIPTION
EDSemver seems to work just fine on tvOS but cannot be used directly from Cocoapods (without forking) because its podspec doesn't explicitly declare support for tvOS. This one-liner adds that declaration to EDSemver.podspec
